### PR TITLE
Ensure no concurrent read

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ function ctor(opts, read) {
   inherits(Class, Readable)
   function Class() {
     if (!(this instanceof Class)) return new Class
+    this._reading = false
     Readable.call(this, opts)
   }
 
@@ -28,11 +29,14 @@ function ctor(opts, read) {
   Class.prototype._read = function(size) {
     var self = this
 
+    if (this._reading) return
+    this._reading = true
     this._from(size, check)
     function check(err, data) {
       if (err) return self.emit('error', err)
       if (data === null) return self.push(null)
-      if (self.push(data)) self._from(size, check)
+      self._reading = false
+      if (self.push(data)) self._read()
     }
   }
 


### PR DESCRIPTION
Currently _from will be called multiple times concurrently if you do a something asynchronously read

``` js
var rs = from(function(size, cb) {
  console.log('reading')
  setTimeout(function() {
    console.log('not reading')
    cb(null, 'test')
  }, 100)
})

rs.resume()
```

Running the above will print something like

```
reading
not reading
reading
reading
```

This PR fixes this
