### PR TITLE
default hwm to 16 for obj mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ function obj(opts, read) {
 
   opts = defaults(opts)
   opts.objectMode = true
+  opts.highWaterMark = 16
 
   return from2(opts, read)
 }


### PR DESCRIPTION
Similar to a PR I did for through this defaults hwm to 16 for object mode (default in node 0.10 is 16.000 objects). This is fixed in node 0.12
