### PR TITLE
Add from2-array to a See Also section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ of creating one-off streams on each call.
 Takes the same options as `from2`, instead returning a constructor which you
 can use to create new streams.
 
+### See Also
+
+- [from2-array](https://github.com/binocarlos/from2-array) - Create a from2 stream based on an array of source values.
+
 ## License ##
 
 MIT. See [LICENSE.md](http://github.com/hughsk/from2/blob/master/LICENSE.md) for details.


### PR DESCRIPTION
Found out about from2 and from2-array today.  This would make from2-array a little more discoverable, and was inspired by github.com/rvagg/through2#see-also.  Are there any other known from2 wrappers that should also be added?

Just wondering, is there a to2 that is a similar Convince wrapper for writable streams?