### PR TITLE
Changed the behavior of next under no arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 before_install:
-  - npm install -g npm
+  - npm install -g npm@4.2.0
 node_js:
   - "0.8"
   - "0.10"

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function ctor(opts, read) {
       if (err) return self.destroy(err)
       if (data === null) return self.push(null)
       self._reading = false
-      if (self.push(data)) self._read(hwm)
+      if (data === undefined || self.push(data)) self._read(hwm)
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -135,7 +135,6 @@ test('not push undefined', function(t) {
       });
     }
   })
-
   stream.on('data', function(data) {
     t.notEqual(data, undefined)
   }).on('end', function() {

--- a/test.js
+++ b/test.js
@@ -120,4 +120,26 @@ test('obj arrays can emit errors', function (t) {
   })
 })
 
+test('not push undefined', function(t) {
+  var first = true;
+  var stream = from.obj(function(size, next) {
+    if (first){
+      process.nextTick(function() {
+        stream.push({});
+        next();
+      });
+      first = false;
+    } else {
+      process.nextTick(function() {
+        next(null,null);
+      });
+    }
+  })
 
+  stream.on('data', function(data) {
+    t.notEqual(data, undefined)
+  }).on('end', function() {
+    t.ok(true)
+    t.end()
+  })
+})


### PR DESCRIPTION
I added a check to skip pushing undefined to stream. The situation happens when next is called without second argument. It is useful if user want to push multiple chunks in loop and does not want to save a last chunk for next call.

In response to hughsk/from2#17

The change in .travis.yml is not related to functionality but was required to make travis build pass